### PR TITLE
Restricts autoinstaller unit tests to local architecture.

### DIFF
--- a/autoinstaller/autoinstaller.xcodeproj/project.pbxproj
+++ b/autoinstaller/autoinstaller.xcodeproj/project.pbxproj
@@ -876,6 +876,7 @@
 					"\"$(DEVELOPER_FRAMEWORKS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Resources/Extensions Tests-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SenTestingKit,
@@ -898,6 +899,7 @@
 					"\"$(DEVELOPER_FRAMEWORKS_DIR)\"",
 				);
 				INFOPLIST_FILE = "Resources/Extensions Tests-Info.plist";
+				ONLY_ACTIVE_ARCH = YES;
 				OTHER_LDFLAGS = (
 					"-framework",
 					SenTestingKit,


### PR DESCRIPTION
Without this fix, building with Xcode 3.1 on a Mac Pro running 10.9.5
was attempting to include a ppc build and failing.  There was already
a config file that purported to fix this just to avoid running the
tests under Rosetta (back when Rosetta existed), but it wasn't working.

This fix precludes running both 32- and 64-bit builds of the tests (and
actually winds up running in 32-bit mode, even on a 64-bit machine), but
Xcode seems to lack sufficient flexibility to get this right.
