### PR TITLE
Using HTTPS to fetch list of releases

### DIFF
--- a/OSXFUSEPref.m
+++ b/OSXFUSEPref.m
@@ -13,7 +13,7 @@ static NSString *kAutoInstallToolName = @"autoinstall-osxfuse-core";
 static NSString *kRemoveToolPath = @"/Library/Filesystems/osxfuse.fs/Contents/Resources/uninstall_osxfuse.app";
 static NSString *kPreferencesName = @"com.github.osxfuse.OSXFUSE.plist";
 static NSString *kURLKey = @"URL";
-static NSString *kBetaValue = @"http://osxfuse.github.io/releases/DeveloperRelease.plist";
+static NSString *kBetaValue = @"https://osxfuse.github.io/releases/DeveloperRelease.plist";
 static const NSTimeInterval kNetworkTimeOutInterval = 15; 
 
 @interface OSXFUSEPref (PrivateMethods)

--- a/autoinstaller/main.m
+++ b/autoinstaller/main.m
@@ -22,7 +22,7 @@
 
 // The URL to the KSPlistServer-style rules plist to use for OSXFUSE updates.
 static NSString* const kDefaultRulesURL =
-  @"http://osxfuse.github.io/releases/CurrentRelease.plist";
+  @"https://osxfuse.github.io/releases/CurrentRelease.plist";
 
 
 // Usage

--- a/com.github.osxfuse.OSXFUSE.plist
+++ b/com.github.osxfuse.OSXFUSE.plist
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>URL</key>
-	<string>http://osxfuse.github.io/releases/DeveloperRelease.plist</string>
+	<string>https://osxfuse.github.io/releases/DeveloperRelease.plist</string>
 </dict>
 </plist>


### PR DESCRIPTION
PrefPane should use secure URLs to fetch list of releases