### PR TITLE
Add support for preferences URL scheme

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -30,6 +30,8 @@
 	<string>FUSE</string>
 	<key>NSPrefPaneSearchParameters</key>
 	<string>OSXFUSE</string>
+	<key>NSPrefPaneAllowsXAppleSystemPreferencesURLScheme</key>
+	<true/>
 	<key>NSPrincipalClass</key>
 	<string>OSXFUSEPref</string>
 </dict>


### PR DESCRIPTION
Allow others to open the pane via the scheme
x-apple.systempreferences:com.github.osxfuse.OSXFUSEPrefPane

I wanted to open the preference pane directly from my app to navigate the user to the place where the kernel extension can be updated. This worked until 10.10 but has gotten a restriction with 10.11 and later.
A (from Apple's side undocumented) key has to be added to the Info.plist to re-add the functionality.

See also:
http://stackoverflow.com/a/24703872